### PR TITLE
various fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ coverage
 # Debugging Files
 debug/*
 !debug/sample.html
+!debug/async-sample.html
 
 # Built Files
 dist/**/*.js

--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ L.esri.GP.Tasks.Geoprocessing accepts all L.esri.Tasks.Task options.
 Method | Returns | Description
 --- | --- | ---
 `setParam(<String> inputParamName, <String||Boolean||Number||Geometry> value)` | `this` | Sets an input parameter.  L.LatLng, L.Marker, L.LatLngBounds, and L.GeoJSON (both Features and Geometries) will be converted to [GeoServices](http://resources.arcgis.com/en/help/arcgis-rest-api/index.html#/Geometry_objects/02r3000000n1000000/) JSON automatically.
+`setOutputParam(<String> outputParamName)` | `this` | Only applicable for asynchronous services.  Nofifies the plugin of the parameter name so that it knows where to retrieve output.
 `run(<Function> callback)` | `this` | Calls the corresponding Geoprocessing service, passing the previously supplied input parameters.
 `gpAsyncResultParam(<String> resultParamName, <Object> value)` | `this` | Sets a result parameter for Asynchronous geoprocessing services that require it.
 

--- a/debug/async-sample.html
+++ b/debug/async-sample.html
@@ -1,0 +1,76 @@
+<html>
+<head>
+  <meta charset=utf-8 />
+  <title>drivetimes</title>
+  <meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no' />
+
+  <!-- Load Leaflet -->
+  <link rel="stylesheet" href="../node_modules/leaflet/dist/leaflet.css" />
+  <script src="../node_modules/leaflet/dist/leaflet-src.js"></script>
+
+  <!-- Load Esri Leaflet -->
+  <script src="../node_modules/esri-leaflet/dist/esri-leaflet-src.js"></script>
+
+  <script src="../src/EsriLeafletGP.js"></script>
+  <script src="../src/Services/Geoprocessing.js"></script>
+  <script src="../src/Tasks/Geoprocessing.js"></script>
+
+  <style>
+    body {margin:0;padding:0;}
+    #map {
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      right: 0;
+      left: 0;
+    }
+    #info-pane {
+      position: absolute;
+      top: 10px;
+      right: 10px;
+      z-index: 10;
+      padding: 1em;
+      background: white;
+    }
+  </style>
+</head>
+<body>
+<div id="map"></div>
+<div id="info-pane" class="leaflet-bar">
+  <label>
+  click on the map to calculate 1 and 2 minute drivetimes
+  </label>
+</div>
+
+<script>
+  var map = L.map('map').setView([42.36, -71.06], 13);
+  L.esri.basemapLayer('Gray').addTo(map);
+
+  var gpService = new L.esri.GP.Services.Geoprocessing({
+    url: 'http://logistics.arcgis.com/arcgis/rest/services/World/ServiceAreas/GPServer/GenerateServiceAreas',
+    /* insert hardcoded token from:
+    https://developers.arcgis.com/en/applications/  */
+    token: 'M3Fo-MMiJUO8ByJu8y7qdg8M7IcZFu9TRQt7oWO3X2f3xjBNr89tEv1w7dZVoP9eQ6EFtGWwlT0eRmZONSC013N4e0fS50NOr28Cgjog1V8JWLBxDxKPDAV6VG8_cnV1BkY-u_kO0N_Yzpe6BWsZ5g..'
+  });
+
+  var gpTask = gpService.createTask();
+  gpTask.setParam('break_values', '1 2');
+  gpTask.setOutputParam('Service_Areas');
+  var driveTimes = new L.FeatureGroup();
+  map.addLayer(driveTimes);
+
+  map.on('click', function(evt){
+    document.getElementById('info-pane').innerHTML = 'working...';
+    driveTimes.clearLayers();
+    gpTask.setParam("facilities", evt.latlng)
+    gpTask.run(driveTimeCallback);
+  });
+
+  function driveTimeCallback(error, response, raw){
+    document.getElementById('info-pane').innerHTML = 'click on the map to calculate 1 and 2 minute drivetimes';
+    driveTimes.addLayer(L.geoJson(response));
+  }
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
* allow developers to specify the name of asyncronous output parameters
* dont request async output more than once, even if multiple status requests get queued

closes #15, #16, #19