### PR TITLE
2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [Unreleased][unreleased]
+
+## [2.0.1]
+
+### Fixed
+
+* add `package.json` browser bundle pointing at built library.
+
+### Changed
+
+* Build system refactored to use latest Rollup and Rollup plugins.
+* Reworked bundling directives for various modules systems to resolve and simplify various issues
+  * WebPack users no longer have to use the Babel loader.
+  * Babelify with Babel 6 now works
+
 ## [2.0.0]
 
 ### Changed
@@ -63,6 +78,8 @@ This is expected to be the last (and only) stable release of Esri Leaflet GP com
 - refactored code to follow pattern established by [esri-leaflet-geocoder](https://github.com/Esri/esri-leaflet-geocoder)
 - introduced ability to check properties of GP services that don't support CORS
 
+[unreleased]: https://github.com/jgravois/esri-leaflet-gp/compare/v2.0.1...HEAD
+[2.0.1]: https://github.com/jgravois/esri-leaflet-gp/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/jgravois/esri-leaflet-gp/compare/v2.0.0-beta.1...v2.0.0
 [2.0.0-beta.1]: https://github.com/jgravois/esri-leaflet-gp/compare/v1.0.2...v2.0.0-beta.1
 [1.0.2]: https://github.com/jgravois/esri-leaflet-gp/compare/v1.0.1...v1.0.2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,0 @@
-Esri welcomes contributions from anyone and everyone. Please see our [guidelines for contributing](https://github.com/esri/contributing).

--- a/README.md
+++ b/README.md
@@ -18,15 +18,14 @@ Take a look at this [calculate drivetime demo](http://esri.github.io/esri-leafle
   <meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no' />
 
   <!-- Load Leaflet from CDN-->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/leaflet/1.0.0-beta.2/leaflet.css" />
-  <script src="https://cdn.jsdelivr.net/leaflet/1.0.0-beta.2/leaflet.js"></script>
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.0.0-rc.3/dist/leaflet.css" />
+  <script src="https://unpkg.com/leaflet@1.0.0-rc.3"></script>
 
   <!-- Load Esri Leaflet from CDN -->
-  <script src="https://cdn.jsdelivr.net/leaflet.esri/2.0.0-beta.8/esri-leaflet.js"></script>
+  <script src="https://unpkg.com/esri-leaflet@2.0.3"></script>
 
   <!-- Esri Leaflet GP -->
-  <script src="https://cdn.jsdelivr.net/leaflet.esri.gp/2.0.0/esri-leaflet-gp.js"></script>
-
+  <script src="https://unpkg.com/esri-leaflet-gp@2.0.1"></script>
 
   <style>
     body {
@@ -120,7 +119,7 @@ Find a bug or want to request a new feature?  Please let us know by submitting a
 
 ## Contributing
 
-Esri welcomes contributions from anyone and everyone. Please see our [guidelines for contributing](https://github.com/esri/contributing).
+Esri welcomes contributions from anyone and everyone. Please see our [guidelines for contributing](https://github.com/Esri/esri-leaflet/blob/master/CONTRIBUTING.md).
 
 ## Terms and Conditions
 

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,5 @@
 {
   "name": "esri-leaflet-gp",
-  "version": "v2.0.0-beta.1",
   "main": "dist/esri-leaflet-gp.js",
   "ignore": [
     "**/.*",

--- a/elevation.html
+++ b/elevation.html
@@ -5,17 +5,17 @@
   <meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no' />
 
   <!-- Load D3 from CDN-->
-  <script src="http://d3js.org/d3.v3.min.js" charset="utf-8"></script>
+  <script src="https://d3js.org/d3.v3.min.js" charset="utf-8"></script>
 
   <!-- Load Leaflet from CDN-->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/leaflet/1.0.0-beta.2/leaflet.css" />
-  <script src="https://cdn.jsdelivr.net/leaflet/1.0.0-beta.2/leaflet.js"></script>
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.0.0-rc.3/dist/leaflet.css" />
+  <script src="https://unpkg.com/leaflet@1.0.0-rc.3"></script>
 
   <!-- Load Esri Leaflet from CDN -->
-  <script src="https://cdn.jsdelivr.net/leaflet.esri/2.0.0-beta.8/esri-leaflet.js"></script>
+  <script src="https://unpkg.com/esri-leaflet@2.0.3"></script>
 
-  <!-- Load Esri Leaflet GP from CDN -->
-  <script src="https://cdn.jsdelivr.net/leaflet.esri.gp/2.0.0/esri-leaflet-gp.js"></script>
+  <!-- Esri Leaflet GP -->
+  <script src="https://unpkg.com/esri-leaflet-gp@2.0.1"></script>
 
   <script src="./support/Leaflet.Elevation-0.0.2.src.js"></script>
   <link rel="stylesheet" href="./support/Leaflet.Elevation-0.0.2.css">

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "esri-leaflet-gp",
   "description": "A Leaflet plugin for interacting with ArcGIS geoprocessing services.",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "author": "John Gravois <jgravois@esri.com> (http://johngravois.com)",
   "browser": "dist/esri-leaflet-gp-debug.js",
   "bugs": {
@@ -14,8 +14,8 @@
     "Rowan Winsemius"
   ],
   "dependencies": {
-    "leaflet": "^1.0.0-beta.2",
-    "esri-leaflet": "^2.0.0-beta.8"
+    "leaflet": "^1.0.0-rc.3",
+    "esri-leaflet": "^2.0.0"
   },
   "devDependencies": {
     "chai": "2.3.0",


### PR DESCRIPTION
* move cdn to unpkg.com
* get rid of CONTRIBUTING.md (just point folks at esri leaflet's)
* load d3 over https in elevation sample