### PR TITLE
allow passing raw geometries, pass back errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ debug/*
 !debug/sample-mapService.html
 !debug/sample-async.html
 !debug/closest-facility.html
+!debug/histogram.html
 
 # Built Files
 dist/

--- a/debug/histogram.html
+++ b/debug/histogram.html
@@ -1,7 +1,7 @@
 <html>
 <head>
   <meta charset=utf-8 />
-  <title>drivetimes</title>
+  <title>histograms</title>
   <meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no' />
 
   <!-- Load Leaflet from CDN-->
@@ -34,7 +34,7 @@
 <div id="map"></div>
 <div id="info-pane" class="leaflet-bar">
   <label>
-  click on the map to calculate 1 and 2 minute drivetimes
+  lets fetch a histogram.
   </label>
 </div>
 
@@ -43,29 +43,22 @@
   L.esri.basemapLayer('Gray').addTo(map);
 
   var gpService = L.esri.GP.service({
-    url: "http://sampleserver1.arcgisonline.com/ArcGIS/rest/services/Network/ESRI_DriveTime_US/GPServer/CreateDriveTimePolygons",
-    useCors:false
+    url: "https://landsat.arcgis.com/arcgis/rest/services/LandsatGLS/MS/ImageServer/",
+    path: "computeHistograms"
   });
-
-  var driveTimes = new L.FeatureGroup();
 
   var gpTask = gpService.createTask();
-  gpTask.setParam("Drive_Times", "1 2");
 
-  gpTask.setParam("linearUnitParam", { "distance": 3, "units": "esriMiles" })
-  map.addLayer(driveTimes);
+  // gpTask.setParam("geometryType", "esriGeometryPolygon");
+  // var stringifiedEsriPoly = '{"rings":[[[-149.52,64.277],[-149.52,64.48],[-148.53,64.48], [-148.53,64.27]]], "spatialReference":{"wkid":"4326"}}'
+  // gpTask.setParam("geometry", stringifiedEsriPoly);
 
-  map.on('click', function(evt){
-    document.getElementById('info-pane').innerHTML = 'working...';
-    driveTimes.clearLayers();
-    gpTask.setParam("Input_Location", evt.latlng)
-    gpTask.run(driveTimeCallback);
+  gpTask.setParam("geometryType", "esriGeometryEnvelope");
+  gpTask.setParam("geometry", map.getBounds());
+
+  gpTask.run(function(error, response, raw){
+    console.log(response.histograms);
   });
-
-  function driveTimeCallback(error, response, raw){
-    document.getElementById('info-pane').innerHTML = 'click on the map to calculate 1 and 2 minute drivetimes';
-    driveTimes.addLayer(L.geoJson(response.Output_Drive_Time_Polygons));
-  }
 </script>
 
 </body>

--- a/debug/sample-async.html
+++ b/debug/sample-async.html
@@ -44,7 +44,7 @@
 
   var gpService = L.esri.GP.service({
     url: 'http://utility.arcgis.com/usrsvcs/appservices/ZSSLB8sUOalOH2wb/rest/services/World/ServiceAreas/GPServer/GenerateServiceAreas',
-    asyncInterval: 2
+    asyncInterval: 1
   });
 
   var gpTask = gpService.createTask();


### PR DESCRIPTION
in an attempt to resolve #40, this introduces support for structuring `geometry` parameter values appropriately
```js
gpTask.setParam("geometryType", "esriGeometryEnvelope");
gpTask.setParam("geometry", map.getBounds());

// geometry:{"xmin":-71.17458343505861,"ymin":42.32212800219525,"xmax":-70.94541549682619,"ymax":42.39785448671501,"spatialReference":{"wkid":4326}}

gpTask.setParam("anythingElse", map.getBounds());

// anythingElse:{"geometryType":"esriGeometryEnvelope","features":[{"geometry":{"xmin":-71.17458343505861,"ymin":42.32212800219525,"xmax":-70.94541549682619,"ymax":42.39785448671501,"spatialReference":{"wkid":4326}}}]}
```

it also:
* ensures generic sync errors are caught and passed back to the user
* ensures `GPLinearUnit` objects are passed along appropriately
* _starts_ to better organize some internal logic
* moves to using private method names for some of the volatile internal logic