### PR TITLE
fix: upgrade to esri-leaflet 3.0.2 which fixes webpack 5 errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   ],
   "dependencies": {
     "leaflet": "^1.0.0",
-    "esri-leaflet": "^2.0.0"
+    "esri-leaflet": "^3.0.2"
   },
   "devDependencies": {
     "chai": "2.3.0",


### PR DESCRIPTION
With this you can use Webpack 5 without warnings (or even errors in case of angular 12).
[Fixed issue in esri-leaflet lib](https://github.com/Esri/esri-leaflet/pull/1273)


https://webpack.js.org/migrate/5/#cleanup-the-code

Using named exports from JSON modules: this is not supported by the new specification and you will get a warning. Instead of import { version } from './package.json' use import package from './package.json'; const { version } = package;